### PR TITLE
Fix manifest include and setup.py requirements.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
-CONTRIBUTING.md
-README.md
-LICENSE
+include CONTRIBUTING.md
+include README.md
+include LICENSE
 
 # Documentation
 graft docs

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ if 'develop' in sys.argv or any(a.startswith('bdist') for a in sys.argv):
 setuptools_args = {}
 
 install_requires = setuptools_args['install_requires'] = [
-    'traitlets'
+    'traitlets>=4.1.0b1'
 ]
 
 extras_require = setuptools_args['extras_require'] = {


### PR DESCRIPTION
Same as the recent change by @minrk on traitlets. This is also fixing the setup.py requirement to get `traitlets>=4.1.0b1`.