### PR TITLE
Overload set

### DIFF
--- a/traittypes/tests/test_traittypes.py
+++ b/traittypes/tests/test_traittypes.py
@@ -5,29 +5,49 @@
 # Distributed under the terms of the Modified BSD License.
 
 from unittest import TestCase
-from traitlets import HasTraits
+from traitlets import HasTraits, observe
 from traitlets.tests.test_traitlets import TraitTestBase
 from traittypes import Array
 import numpy as np
 
 
-class ArrayTraitTestBase(TraitTestBase):
-    """A best testing class for numpy trait types.
-
-    :meth:`assertEqual` is overloaded to not use the `__eq__` operator.
-    """
-
-    def assertEqual(self, v1, v2):
-        return np.testing.assert_array_equal(v1, v2)
+# Good / Bad value trait test cases
 
 
 class IntArrayTrait(HasTraits):
     value = Array().tag(dtype=np.int)
 
 
-class TestIntArray(ArrayTraitTestBase):
-    """Test d-type validation with a ``dtype=np.int``."""
+class TestIntArray(TraitTestBase):
+    """
+    Test dtype validation with a ``dtype=np.int``
+    """
     obj = IntArrayTrait()
 
     _good_values = [1, [1, 2, 3], [[1, 2, 3], [4, 5, 6]], np.array([1])]
     _bad_values = [[1, [0, 0]]]
+
+
+    def assertEqual(self, v1, v2):
+        return np.testing.assert_array_equal(v1, v2)
+
+
+# Other test cases
+
+
+class TestArray(TestCase):
+
+    def test_array_equal(self):
+        notifications = []
+
+        class Foo(HasTraits):
+            bar = Array(default_value=[1, 2])
+            @observe('bar')
+            def _(self, change):
+                notifications.append(change)
+
+        foo = Foo()
+        foo.bar = [1, 2]
+        self.assertFalse(len(notifications))
+        foo.bar = [1, 1]
+        self.assertTrue(len(notifications))

--- a/traittypes/traittypes.py
+++ b/traittypes/traittypes.py
@@ -14,3 +14,10 @@ class Array(TraitType):
                               order=self.get_metadata('order'))
         except (ValueError, TypeError) as e:
             raise TraitError(e)
+
+    def set(self, obj, value):
+        new_value = self._validate(obj, value)
+        old_value = obj._trait_values.get(self.name, self.default_value)
+        obj._trait_values[self.name] = new_value
+        if not np.array_equal(old_value, new_value):
+            obj._notify_trait(self.name, old_value, new_value)


### PR DESCRIPTION
The behavior of `traitlets.TraitType.set` when `__eq__` fails is to always send a notification, even when the objects are actually equal.

Overriding `set`  in trait types like Array for which `==` does an element-wise comparison solves this issue.